### PR TITLE
release v0.3.0

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,14 @@
-{
-	"ignorePatterns": [
-		"node_modules/**",
-		"src/iconoir/**",
-		"dist/**"
-	]
-}
+.DS_Store
+node_modules
+/build
+/.svelte-kit
+/packages
+/dist
+.env
+.env.*
+!.env.example
+
+# Ignore files for PNPM, NPM and YARN
+pnpm-lock.yaml
+package-lock.json
+yarn.lock

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,15 +6,15 @@ module.exports = {
 	ignorePatterns: ['*.cjs'],
 	overrides: [{ files: ['*.svelte'], processor: 'svelte3/svelte3' }],
 	settings: {
-		'svelte3/typescript': () => require('typescript'),
+		'svelte3/typescript': () => require('typescript')
 	},
 	parserOptions: {
 		sourceType: 'module',
-		ecmaVersion: 2020,
+		ecmaVersion: 2020
 	},
 	env: {
 		browser: true,
 		es2017: true,
-		node: true,
-	},
+		node: true
+	}
 };

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,55 +1,55 @@
 name: Publish
 on:
-    release:
-        types: [created]
+  release:
+    types: [created]
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            packages: write
-        steps:
-            - uses: actions/checkout@v3
-              with:
-                  submodules: recursive
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-            - name: Setup Node
-              uses: actions/setup-node@v3
-              with:
-                  node-version: 16
-                  registry-url: 'https://registry.npmjs.org'
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: 'https://registry.npmjs.org'
 
-            - name: Install PNPM
-              run: npm install --location=global pnpm
+      - name: Install PNPM
+        run: npm install --location=global pnpm
 
-            - name: Install all dependencies
-              run: pnpm install --no-frozen-lockfile
+      - name: Install all dependencies
+        run: pnpm install --no-frozen-lockfile
 
-            - name: Generates the icons components
-              run: pnpm generate:icons
+      - name: Generates the icons components
+        run: pnpm generate:icons
 
-            - name: Run Prettier format
-              run: pnpm format
+      - name: Run Prettier format
+        run: pnpm format
 
-            - name: Run Prettier lint
-              run: pnpm lint
+      - name: Run Prettier lint
+        run: pnpm lint
 
-            - name: Build the package
-              run: pnpm package
+      - name: Build the package
+        run: pnpm build
 
-            - name: Publish to NPM Packages
-              run: npm publish --access public ./dist
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
+      - name: Publish to NPM Packages
+        run: npm publish --access public ./dist
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
 
-            - name: Setup .npmrc file to publish to GitHub Packages
-              uses: actions/setup-node@v2
-              with:
-                  node-version: '16.x'
-                  registry-url: 'https://npm.pkg.github.com'
-                  scope: '@indaco'
+      - name: Setup .npmrc file to publish to GitHub Packages
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@indaco'
 
-            - name: Publish to GitHub Packages
-              run: npm publish ./dist
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish to GitHub Packages
+        run: npm publish ./dist
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,13 +2,11 @@
 node_modules
 /build
 /.svelte-kit
-/package
+/packages
+/dist
 .env
 .env.*
 !.env.example
-/static
-/dist
-packages/**
 README.md
 
 # Ignore files for PNPM, NPM and YARN

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,25 +1,9 @@
 {
 	"useTabs": true,
 	"singleQuote": true,
+	"trailingComma": "none",
 	"printWidth": 100,
-	"trailingComma": "all",
-	"tabWidth": 4,
-	"bracketSpacing": true,
-	"bracketSameLine": true,
-	"arrowParens": "always",
-	"overrides": [
-		{
-			"files": ["*.svelte"],
-			"options": {
-				"bracketSameLine": false
-			}
-		},
-		{
-			"files": ["README.md"],
-			"options": {
-				"useTabs": false,
-				"tabWidth": 2
-			}
-		}
-	]
+	"plugins": ["prettier-plugin-svelte"],
+	"pluginSearchDirs": ["."],
+	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # Svelte Iconoir
 
-> `svelte-iconoi@2.6.2` matches `iconoir@5.3.1`
+> `svelte-iconoi@3.0.0` matches `iconoir@5.3.1`
 
 ## Description
 
@@ -39,8 +39,8 @@ Each icon is available to be used/imported following the **CamelCase** notation.
 ```html
 <script>
  import { SunLightIcon } from '@indaco/svelte-iconoir';
- // or use THIS approach in dev
- import ListIcon from '@indaco/svelte-iconoir/icons/ListIcon.svelte';
+ // to speed up dev server loading, use this
+ import { ListIcon } from '@indaco/svelte-iconoir/icons/ListIcon';
 </script>
 
 <ListIcon />
@@ -61,7 +61,7 @@ Each icon is available to be used/imported following the **CamelCase** notation.
 
 ```html
 <script>
- import View360Icon from '@indaco/svelte-iconoir/icons/View360Icon.svelte';
+ import { View360Icon } from '@indaco/svelte-iconoir/icons/View360Icon';
 </script>
 
 <View360Icon
@@ -73,7 +73,7 @@ Each icon is available to be used/imported following the **CamelCase** notation.
 
 ```html
 <script>
- import ActivityIcon from '@indaco/svelte-iconoir/icons/ActivityIcon.svelte';
+ import { ActivityIcon } from '@indaco/svelte-iconoir/icons/ActivityIcon';
 </script>
 
 <ActivityIcon class="p-1 rounded-full border-2 bg-green-400" size="2.5em" />
@@ -85,7 +85,7 @@ You can also override the `click, dblclick` events on an element.
 
 ```html
 <script>
- import ActivityIcon from '@indaco/svelte-iconoir/icons/ActivityIcon.svelte';
+ import { ActivityIcon } from '@indaco/svelte-iconoir/icons/ActivityIcon';
 </script>
 
 <ActivityIcon class="p-1 rounded-full border-6 bg-blue-300" on:click={() => alert("hi!")} size="2.5em" />
@@ -117,7 +117,7 @@ pnpm install # (or npm, yarn)
 pnpm generate:icons
 
 # Package
-pnpm package
+pnpm build
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
 		"svelte": "^3.50.1",
 		"svelte-check": "^2.9.0",
 		"svelte-preprocess": "^4.10.7",
-		"svelte2tsx": "^0.5.18",
 		"svg-parser": "^2.0.4",
 		"tslib": "^2.4.0",
 		"typescript": "^4.8.3",
@@ -46,28 +45,16 @@
 	},
 	"scripts": {
 		"dev": "svelte-kit sync && vite dev",
-		"build": "svelte-kit sync && vite build",
-		"package": "pnpm clean:dist && svelte-kit sync && svelte-package",
+		"build": "rimraf dist && svelte-kit sync && svelte-package",
 		"preview": "vite preview",
-		"generate:icons": "svelte-kit sync && tsc && pnpm clean && node build/scripts/buildIconsDataset.js",
-		"clean": "tsc && node build/scripts/cleanAll.js",
-		"clean:dist": "rimraf dist",
-		"clean:all": "npm run clean && pnpm clean:dist",
+		"generate:icons": "svelte-kit sync && tsc --outDir build/scripts && pnpm clean && node build/scripts/buildIconsDataset.js",
+		"clean": "tsc --outDir build/scripts && node build/scripts/cleanAll.js",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"format": "prettier --ignore-path .prettierignore --write --plugin-search-dir=. .",
-		"lint": "prettier --ignore-path .prettierignore  --check --plugin-search-dir=. . && eslint --ignore-path .gitignore ."
+		"lint": "prettier --plugin-search-dir . --check . && eslint .",
+		"format": "prettier --plugin-search-dir . --write ."
 	},
 	"types": "index.d.ts",
-	"svelte": "index.js",
 	"sideEffects": false,
-	"publishConfig": {
-		"directory": "dist"
-	},
-	"exports": {
-		".": {
-			"import": "./index.js",
-			"types": "./types.d.ts"
-		}
-	}
+	"svelte": "./index.js"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,6 @@ specifiers:
   svelte: ^3.50.1
   svelte-check: ^2.9.0
   svelte-preprocess: ^4.10.7
-  svelte2tsx: ^0.5.18
   svg-parser: ^2.0.4
   tslib: ^2.4.0
   typescript: ^4.8.3
@@ -42,7 +41,6 @@ devDependencies:
   svelte: 3.50.1
   svelte-check: 2.9.0_svelte@3.50.1
   svelte-preprocess: 4.10.7_iprco5tylfmvffqgrvqxc46njy
-  svelte2tsx: 0.5.18_iprco5tylfmvffqgrvqxc46njy
   svg-parser: 2.0.4
   tslib: 2.4.0
   typescript: 4.8.3

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="@sveltejs/kit" />
+
+// See https://kit.svelte.dev/docs/types#app
+// for information about these interfaces
+// and what to do when importing types
+declare namespace App {
+	// interface Locals {}
+	// interface PageData {}
+	// interface Error {}
+	// interface Platform {}
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@sveltejs/kit" />

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -8,12 +8,12 @@ const config = {
 	preprocess: preprocess(),
 
 	kit: {
-		adapter: adapter(),
+		adapter: adapter()
 	},
+
 	package: {
-		dir: 'dist',
-		emitTypes: false,
-	},
+		dir: 'dist'
+	}
 };
 
 export default config;

--- a/svelte.d.ts
+++ b/svelte.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="svelte" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,16 +8,7 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": true,
-		"strict": true,
-		"outDir": "./build",
-		"rootDir": "."
+		"strict": true
 	},
-	"include": [
-		"src/**/*.d.ts",
-		"scripts/**/*.ts",
-		"src/**/*.js",
-		"src/**/*.ts",
-		"src/**/*.svelte",
-		"package"
-	]
+	"include": ["scripts/**/*.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import type { UserConfig } from 'vite';
 
 const config: UserConfig = {
-	plugins: [sveltekit()],
+	plugins: [sveltekit()]
 };
 
 export default config;


### PR DESCRIPTION
**Bug fixes:**

- typescript config and scripts to make svelte-package with emitTypes working
- progressbar value to reflect the real icons counter

**Breaking:**

- each icon is placed within its own folder with export adhering to Node's ESM algorithm
- to use a single icon the import is now as the following

   ```javascript
   import { ActivityIcon } from '@indaco/svelte-iconoir/icons/ActivityIcon';
   ```

**Features:**

- each icon component has its own Type definition