### PR TITLE
fix: support Svelte 5 in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "vite": "^5.4.11"
   },
   "peerDependencies": {
-    "svelte": "^3.59.1 || ^4.0.0"
+    "svelte": "^3.59.1 || ^4.0.0 || ^5.0.0"
   },
   "packageManager": "pnpm@9.12.3"
 }


### PR DESCRIPTION
First off, thank you for the lib - a favourite of mine.

Not sure if you plan to re-write the internals in Svelte 5, but as is, the lib _just works_. Only issue is the minor warning when installing in v5 projects.

Please let me know if I missed anything, or if there is an issue with this.