### PR TITLE
fix(scripts/makeProdPkg): use subpath export patterns to reduce exports map

### DIFF
--- a/scripts/makeProdPkg.ts
+++ b/scripts/makeProdPkg.ts
@@ -1,104 +1,46 @@
-import type {
-	IconVariant,
-	PkgExports,
-	PkgTypesVersions,
-	SvelteComponentExportItem
-} from './index.js';
-import { fileURLToPath } from 'node:url';
-import { join, dirname, basename } from 'node:path';
-import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { makeComponentFilename, makeComponentName, relativePath } from './utils.js';
-import pc from 'picocolors';
+import type { PkgExports, PkgTypesVersions } from './index.js';
+import { join } from 'node:path';
+import { readFileSync, writeFileSync } from 'node:fs';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import pc from 'picocolors';
 
 const DIST_FOLDER = 'dist';
 const PKG_JSON = 'package.json';
-const COMPONENTS_FOLDER = 'components';
-const ICONS_BASE_FOLDER = join(__dirname, '..', '..', 'packages', 'iconoir', 'icons');
-const REGULAR_ICONS = join(ICONS_BASE_FOLDER, 'regular');
-const SOLID_ICONS = join(ICONS_BASE_FOLDER, 'solid');
-const ICONS_FOLDERS = [REGULAR_ICONS, SOLID_ICONS];
-
-const makeIconPaths = (iconVariant: string, filename: string) => {
-	const base = join('icons', iconVariant, filename);
-	return {
-		types: relativePath(join(base, 'index.d.ts')),
-		svelte: relativePath(join(base, 'index.js')),
-		default: relativePath(join(base, 'index.js'))
-	} satisfies SvelteComponentExportItem;
-};
-
-const makeComponentPaths = (iconVariant: string, filename: string, componentFilename: string) => {
-	const base = join('icons', iconVariant, filename, componentFilename);
-	return {
-		types: relativePath(`${base}.d.ts`),
-		svelte: relativePath(base),
-		default: relativePath(base)
-	} satisfies SvelteComponentExportItem;
-};
 
 function main() {
 	console.log(pc.blue('* Generating the package.json file...'));
 
-	const entries: PkgExports = {};
-	const typesVersion: PkgTypesVersions = { '>4.0': {} };
-
-	ICONS_FOLDERS.forEach((folder) => {
-		try {
-			const files = readdirSync(folder);
-
-			files.forEach((filename) => {
-				const iconVariantName = basename(folder) as IconVariant;
-				const iconName = filename.split('.').slice(0, -1).join('.');
-				const iconComponent = makeComponentName(iconName);
-
-				try {
-					const iconPaths = makeIconPaths(iconVariantName, iconName);
-					const componentPaths = makeComponentPaths(
-						iconVariantName,
-						iconName,
-						makeComponentFilename(iconComponent)
-					);
-
-					if (iconVariantName === 'regular') {
-						entries[relativePath(iconName)] = iconPaths;
-						entries[relativePath(join(COMPONENTS_FOLDER, makeComponentFilename(iconComponent)))] =
-							componentPaths;
-					} else {
-						entries[relativePath(join(iconVariantName, iconName))] = iconPaths;
-						entries[
-							relativePath(
-								join(COMPONENTS_FOLDER, iconVariantName, makeComponentFilename(iconComponent))
-							)
-						] = componentPaths;
-					}
-
-					// Build typesVersions
-					if (iconVariantName === 'regular') {
-						typesVersion['>4.0'][iconName] = [iconPaths.types];
-						typesVersion['>4.0'][
-							relativePath(join(COMPONENTS_FOLDER, makeComponentFilename(iconComponent)))
-						] = [componentPaths.types];
-					} else {
-						typesVersion['>4.0'][join(iconVariantName, iconName)] = [iconPaths.types];
-						typesVersion['>4.0'][
-							relativePath(
-								join(COMPONENTS_FOLDER, iconVariantName, makeComponentFilename(iconComponent))
-							)
-						] = [componentPaths.types];
-					}
-				} catch (error) {
-					console.error('Error processing file:', error);
-					// Handle or log the error as needed
-				}
-			});
-		} catch (error) {
-			console.error('Error reading directory:', error);
-			// Handle or log the error as needed
+	const entries: PkgExports = {
+		'./components/solid/*.svelte': {
+			types: './icons/solid/*.svelte.d.ts',
+			svelte: './icons/solid/*.svelte',
+			default: './icons/solid/*.svelte'
+		},
+		'./components/*.svelte': {
+			types: './icons/regular/*.svelte.d.ts',
+			svelte: './icons/regular/*.svelte',
+			default: './icons/regular/*.svelte'
+		},
+		'./solid/*': {
+			types: './icons/solid/*/index.d.ts',
+			svelte: './icons/solid/*/index.js',
+			default: './icons/solid/*/index.js'
+		},
+		'./*': {
+			types: './icons/regular/*/index.d.ts',
+			svelte: './icons/regular/*/index.js',
+			default: './icons/regular/*/index.js'
 		}
-	});
+	};
+
+	const typesVersion: PkgTypesVersions = {
+		'>4.0': {
+			'./components/solid/*.svelte': ['./icons/solid/*.svelte.d.ts'],
+			'./components/*.svelte': ['./icons/regular/*.svelte.d.ts'],
+			'./solid/*': ['./icons/solid/*/index.d.ts'],
+			'./*': ['./icons/regular/*/index.d.ts']
+		}
+	};
 
 	// Read and update package.json
 	const pkgJsonContent = readFileSync(PKG_JSON, 'utf-8');


### PR DESCRIPTION
This PR fixes #61 by switching to [subpath export patterns](https://nodejs.org/api/packages.html#subpath-patterns), significantly reducing the size of the exports map and improving TypeScript/IDE performance.