### PR TITLE
fix(package): remove components/*.svelte subpath exports to avoid Vite optimization issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,9 @@ where:
 ```html
 <script>
   import { SunLightIcon } from '@indaco/svelte-iconoir/sun-light';
-  // or...
-  import SunLightIcon from '@indaco/svelte-iconoir/components/SunLightIcon.svelte';
 
   // variant `solid`
   import { MinusCircleIcon } from '@indaco/svelte-iconoir/solid/minus-circle';
-  // or component import
-  import MinusCircleIcon from '@indaco/svelte-iconoir/components/solid/MinusCircleIcon.svelte';
 </script>
 ```
 

--- a/scripts/makeProdPkg.ts
+++ b/scripts/makeProdPkg.ts
@@ -11,16 +11,6 @@ function main() {
 	console.log(pc.blue('* Generating the package.json file...'));
 
 	const entries: PkgExports = {
-		'./components/solid/*.svelte': {
-			types: './icons/solid/*.svelte.d.ts',
-			svelte: './icons/solid/*.svelte',
-			default: './icons/solid/*.svelte'
-		},
-		'./components/*.svelte': {
-			types: './icons/regular/*.svelte.d.ts',
-			svelte: './icons/regular/*.svelte',
-			default: './icons/regular/*.svelte'
-		},
 		'./solid/*': {
 			types: './icons/solid/*/index.d.ts',
 			svelte: './icons/solid/*/index.js',
@@ -35,8 +25,6 @@ function main() {
 
 	const typesVersion: PkgTypesVersions = {
 		'>4.0': {
-			'./components/solid/*.svelte': ['./icons/solid/*.svelte.d.ts'],
-			'./components/*.svelte': ['./icons/regular/*.svelte.d.ts'],
 			'./solid/*': ['./icons/solid/*/index.d.ts'],
 			'./*': ['./icons/regular/*/index.d.ts']
 		}


### PR DESCRIPTION
This PR removes the `./components/*.svelte` and `./components/solid/*.svelte` wildcard subpath exports from `package.json` to avoid performance issues during Vite dependency optimization.

These `components/*.svelte` subpaths were originally exposed for convenience, but they introduce **duplicate access paths** when used alongside named subpath imports (e.g., `@indaco/svelte-iconoir/sun-light`). This can lead to **slower dev startup times** and increased memory usage, as noted in the [SvelteKit documentation on icon libraries](https://svelte.dev/docs/kit/icons).

Consumers should use named imports like:

```ts
import { SunLightIcon } from '@indaco/svelte-iconoir/sun-light';
import { MinusCircleIcon } from '@indaco/svelte-iconoir/solid/minus-circle';
```